### PR TITLE
Fix PyPi deploying workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,4 +37,4 @@ jobs:
           VERSION: ${{ steps.release_version.outputs.VERSION }}
 
       - name: Deploy to PyPi
-        run: twine upload dist/* --verbose
+        run: twine upload dist/* --verbose --config-file .pypirc

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Deploy to PyPi
         run: twine upload dist/* --verbose --config-file .pypirc
+        env:
+          PYPI_USERNAME: ${{secrets.PYPI_USERNAME}}
+          PYPI_PASSWORD: ${{secrets.PYPI_PASSWORD}}

--- a/.pypirc
+++ b/.pypirc
@@ -1,0 +1,7 @@
+[distutils]
+index-servers =
+  pypi
+
+[pypi]
+username: $PYPI_USERNAME
+password: $PYPI_PASSWORD


### PR DESCRIPTION
Add `PyPi` credentials to permit deploying `Dory` with `twine`.